### PR TITLE
fixing all day not appearing in calendar

### DIFF
--- a/src/calendars/frontmatter.ts
+++ b/src/calendars/frontmatter.ts
@@ -73,7 +73,7 @@ function stringifyYamlLine(k: string, v: PrintableAtom): string {
 export function newFrontmatter(fields: Partial<OFCEvent>): string {
   const newFields = { ...fields };
   if (newFields.type === 'single') delete newFields.type;
-  if (newFields.allDay) delete newFields.allDay;
+  if (!newFields.allDay) delete newFields.allDay;
 
   return Object.entries(newFields)
     .filter(([_, v]) => v !== undefined)


### PR DESCRIPTION
Hey! 

Not sure if this is the maintained project moving forward, but appreciate your work so far on fixing the timezone issues.

Noticed a small bug that prevents `allDay` type events from properly rendering in the Calendar - fixed by adjusting the logic for the frontmatter slightly.