### PR TITLE
fix: fixing off by one error with multi day events

### DIFF
--- a/src/ui/interop.ts
+++ b/src/ui/interop.ts
@@ -260,7 +260,9 @@ export function toEventInput(
       event = {
         ...event,
         start: frontmatter.date,
-        end: frontmatter.endDate || undefined,
+        end: frontmatter.endDate
+          ? (DateTime.fromISO(frontmatter.endDate).plus({ days: 1 }).toISODate() ?? undefined)
+          : undefined,
         extendedProps: {
           ...event.extendedProps,
           isTask: frontmatter.completed !== undefined && frontmatter.completed !== null,


### PR DESCRIPTION

## Fix off-by-one error for multi-day all-day events

**Problem:**
Multi-day all-day events display one day shorter than expected. For example, dragging across 3 days (July 14-16) only shows the event for 2 days (July 14-15).

**Root Cause:**
FullCalendar uses exclusive end dates for all-day events. When we set `end: "2025-07-16"`, FullCalendar interprets this as "ends before July 16th" rather than "ends after July 16th".

**Solution:**
Add 1 day to the end date when converting from OFCEvent to FullCalendar's EventInput format. This ensures the event displays through the intended end date.

**Changes:**
- Modified `toEventInput()` in `src/ui/interop.ts` 
- For all-day events with an end date, add 1 day before passing to FullCalendar
- Frontmatter storage remains unchanged (still stores the user's intended dates)

**Testing:**
- Create multi-day all-day event by dragging across multiple days
- Verify event displays for the correct number of days
- Verify frontmatter contains the expected start/end dates
