### PR TITLE
Fix/external cal multi day events

### DIFF
--- a/src/ui/interop.ts
+++ b/src/ui/interop.ts
@@ -143,7 +143,7 @@ export function toEventInput(
   id: string,
   frontmatter: OFCEvent,
   settings: FullCalendarSettings,
-	calendarId?: string
+  calendarId?: string
 ): EventInput | null {
   let event: EventInput = {
     id,
@@ -257,32 +257,33 @@ export function toEventInput(
           taskCompleted: frontmatter.completed
         }
       };
-		} else {
-			const isLocalCalendar = calendarId?.startsWith('local::');
-			let adjustedEndDate: string | undefined;
+    } else {
+      const isLocalCalendar = calendarId?.startsWith('local::');
+      let adjustedEndDate: string | undefined;
 
-			if (!frontmatter.endDate) {
-				// Single-day event: no end date needed
-				adjustedEndDate = undefined;
-			} else if (isLocalCalendar) {
-				// Multi-day local event: add 1 day to fix FullCalendar's exclusive end date
-				adjustedEndDate = DateTime.fromISO(frontmatter.endDate).plus({ days: 1 }).toISODate() ?? undefined;
-			} else {
-				// Multi-day external event: use as-is
-				adjustedEndDate = frontmatter.endDate;
-			}
+      if (!frontmatter.endDate) {
+        // Single-day event: no end date needed
+        adjustedEndDate = undefined;
+      } else if (isLocalCalendar) {
+        // Multi-day local event: add 1 day to fix FullCalendar's exclusive end date
+        adjustedEndDate =
+          DateTime.fromISO(frontmatter.endDate).plus({ days: 1 }).toISODate() ?? undefined;
+      } else {
+        // Multi-day external event: use as-is
+        adjustedEndDate = frontmatter.endDate;
+      }
 
-			event = {
-				...event,
-				start: frontmatter.date,
-				end: adjustedEndDate,
-				extendedProps: {
-					...event.extendedProps,
-					isTask: frontmatter.completed !== undefined && frontmatter.completed !== null,
-					taskCompleted: frontmatter.completed
-				}
-			};
-		}
+      event = {
+        ...event,
+        start: frontmatter.date,
+        end: adjustedEndDate,
+        extendedProps: {
+          ...event.extendedProps,
+          isTask: frontmatter.completed !== undefined && frontmatter.completed !== null,
+          taskCompleted: frontmatter.completed
+        }
+      };
+    }
   }
 
   return event;

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -92,7 +92,7 @@ export class CalendarView extends ItemView {
       ({ events, editable, color, id }): EventSourceInput => ({
         id,
         // Pass settings to toEventInput
-        events: events.flatMap(e => toEventInput(e.id, e.event, settings) || []),
+        events: events.flatMap(e => toEventInput(e.id, e.event, settings, id) || []),
         editable,
         ...getCalendarColors(color)
       })
@@ -318,7 +318,7 @@ export class CalendarView extends ItemView {
         });
         toAdd.forEach(({ id, event, calendarId }) => {
           // Pass settings to toEventInput
-          const eventInput = toEventInput(id, event, settings);
+          const eventInput = toEventInput(id, event, settings, calendarId);
           // console.debug('adding event', {
           //   id,
           //   event,
@@ -337,7 +337,7 @@ export class CalendarView extends ItemView {
         this.fullCalendarView?.addEventSource({
           id,
           // Pass settings to toEventInput
-          events: events.flatMap(({ id, event }) => toEventInput(id, event, settings) || []),
+					events: events.flatMap(({ id: eventId, event }) => toEventInput(eventId, event, settings, id) || []),
           editable,
           ...getCalendarColors(color)
         });

--- a/src/ui/view.ts
+++ b/src/ui/view.ts
@@ -337,7 +337,9 @@ export class CalendarView extends ItemView {
         this.fullCalendarView?.addEventSource({
           id,
           // Pass settings to toEventInput
-					events: events.flatMap(({ id: eventId, event }) => toEventInput(eventId, event, settings, id) || []),
+          events: events.flatMap(
+            ({ id: eventId, event }) => toEventInput(eventId, event, settings, id) || []
+          ),
           editable,
           ...getCalendarColors(color)
         });


### PR DESCRIPTION

## Fix multi-day all-day events for external calendars

**Problem:**
PR https://github.com/YouFoundJK/plugin-full-calendar/pull/27 fixed the off-by-one error for local multi-day all-day events, but inadvertently broke external calendar events (Google Calendar, ICS feeds) by applying the same date adjustment to all event sources.

**Root Cause:**
The previous fix added 1 day to all multi-day all-day events, but external calendars already provide dates in the format FullCalendar expects. Only local Obsidian events need the adjustment due to different date interpretation conventions.

**Solution:**
- Detect calendar source using calendar ID patterns (`local::` vs `ical::`)
- Apply +1 day adjustment only to local calendar events
- Leave external calendar events unchanged

**Testing:**
- Local multi-day all-day events display correct duration
- Google Calendar/ICS events display as before the regression
- Single-day events work correctly for both sources

**Changes:**
- Modified `toEventInput()` to accept calendar ID parameter
- Updated all callers in `view.ts` to pass calendar context
- Applied date adjustment conditionally based on calendar source
