### PR TITLE
fix (add) gcal settings credentials menu

### DIFF
--- a/src/features/i18n/locales/en.json
+++ b/src/features/i18n/locales/en.json
@@ -544,6 +544,20 @@
   },
   "google": {
     "title": "Google Accounts",
+    "customCredentials": {
+      "enable": {
+        "label": "Use custom Google Cloud credentials",
+        "description": "Use your own OAuth Client ID and Secret instead of the default. Required until the plugin is verified by Google."
+      },
+      "clientId": {
+        "label": "Client ID",
+        "description": "Your Google OAuth 2.0 Client ID"
+      },
+      "clientSecret": {
+        "label": "Client Secret",
+        "description": "Your Google OAuth 2.0 Client Secret"
+      }
+    },
     "noAccounts": "No Google accounts connected. Add a calendar source to connect an account.",
     "accountDescription": "Connected account. ID: {{id}}",
     "buttons": {

--- a/src/providers/google/ui/renderGoogle.ts
+++ b/src/providers/google/ui/renderGoogle.ts
@@ -18,6 +18,48 @@ export function renderGoogleSettings(
 
   new Setting(containerEl).setName(t('google.title')).setHeading();
 
+  // Custom credentials toggle
+  new Setting(containerEl)
+    .setName(t('google.customCredentials.enable.label'))
+    .setDesc(t('google.customCredentials.enable.description'))
+    .addToggle(toggle => {
+      toggle
+        .setValue(plugin.settings.useCustomGoogleClient)
+        .onChange(async value => {
+          plugin.settings.useCustomGoogleClient = value;
+          await plugin.saveSettings();
+          rerender();
+        });
+    });
+
+  // Custom credentials inputs (only shown when toggle is enabled)
+  if (plugin.settings.useCustomGoogleClient) {
+    new Setting(containerEl)
+      .setName(t('google.customCredentials.clientId.label'))
+      .setDesc(t('google.customCredentials.clientId.description'))
+      .addText(text => {
+        text
+          .setValue(plugin.settings.googleClientId)
+          .onChange(async value => {
+            plugin.settings.googleClientId = value;
+            await plugin.saveSettings();
+          });
+      });
+
+    new Setting(containerEl)
+      .setName(t('google.customCredentials.clientSecret.label'))
+      .setDesc(t('google.customCredentials.clientSecret.description'))
+      .addText(text => {
+        text.inputEl.type = 'password';
+        text
+          .setValue(plugin.settings.googleClientSecret)
+          .onChange(async value => {
+            plugin.settings.googleClientSecret = value;
+            await plugin.saveSettings();
+          });
+      });
+  }
+
   const accounts = plugin.settings.googleAccounts || [];
 
   if (accounts.length === 0) {


### PR DESCRIPTION
For some reason the "Use Custom Google Cloud Credentials" toggle mentioned in the [docs](https://youfoundjk.github.io/plugin-full-calendar/calendars/gcal/), and the associated boxes for the client ID and client secret, do not actually show up in the plugin settings UI. this PR fixes that.